### PR TITLE
Use ispc_compile and ispc_rt to feature gate compilation of ISPC code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ maintenance = { status = "actively-developed" }
 ispc_rt = "1.0.1"
 
 [build-dependencies]
-ispc_compile = { version = "1.0.1", optional = true }
+ispc_compile = { version = "1.0.2", optional = true }
 ispc_rt = "1.0.1"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,10 +31,14 @@ edition = "2018"
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-ispc = "0.3.8"
+ispc_rt = "1.0.1"
 
 [build-dependencies]
-ispc = "0.3.8"
+ispc_compile = { version = "1.0.1", optional = true }
+ispc_rt = "1.0.1"
+
+[features]
+ispc = ["ispc_compile"]
 
 [dev-dependencies]
 ddsfile = "0.2.3"

--- a/build.rs
+++ b/build.rs
@@ -18,7 +18,8 @@ fn compile_kernel() {
         .optimization_opt(ispc_compile::OptimizationOpt::FastMath)
         .woff()
         .target_isas(vec![TargetISA::SSE2i32x4, TargetISA::SSE4i32x4,
-                     TargetISA::AVX1i32x8, TargetISA::AVX2i32x8])
+                     TargetISA::AVX1i32x8, TargetISA::AVX2i32x8,
+                     TargetISA::AVX512KNLi32x16, TargetISA::AVX512SKXi32x16])
         .out_dir("src/ispc/")
         .compile("kernel");
 
@@ -28,7 +29,8 @@ fn compile_kernel() {
         .optimization_opt(ispc_compile::OptimizationOpt::FastMath)
         .woff()
         .target_isas(vec![TargetISA::SSE2i32x4, TargetISA::SSE4i32x4,
-                     TargetISA::AVX1i32x8, TargetISA::AVX2i32x8])
+                     TargetISA::AVX1i32x8, TargetISA::AVX2i32x8,
+                     TargetISA::AVX512KNLi32x16, TargetISA::AVX512SKXi32x16])
         .out_dir("src/ispc/")
         .compile("kernel_astc");
 }

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,6 @@
-extern crate ispc;
+extern crate ispc_rt;
+#[cfg(feature = "ispc")]
+extern crate ispc_compile;
 
 /*
     ISPC project file builds the kernels as such:
@@ -6,29 +8,42 @@ extern crate ispc;
     <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(TargetDir)%(Filename).obj;$(TargetDir)%(Filename)_sse2.obj;$(TargetDir)%(Filename)_sse4.obj;$(TargetDir)%(Filename)_avx.obj;$(TargetDir)%(Filename)_avx2.obj;</Outputs>
 */
 
+#[cfg(feature = "ispc")]
 fn compile_kernel() {
-    let mut cfg = ispc::Config::new();
-    cfg.file("vendor/ISPC Texture Compressor/ispc_texcomp/kernel.ispc");
-    cfg.opt_level(2);
-    cfg.optimization_opt(ispc::opt::OptimizationOpt::FastMath);
-    //cfg.quiet();
-    cfg.woff();
-    //cfg.instrument();
-    cfg.compile("kernel");
+    use ispc_compile::TargetISA;
+
+    ispc_compile::Config::new()
+        .file("vendor/ISPC Texture Compressor/ispc_texcomp/kernel.ispc")
+        .opt_level(2)
+        .optimization_opt(ispc_compile::OptimizationOpt::FastMath)
+        .woff()
+        .target_isas(vec![TargetISA::SSE2i32x4, TargetISA::SSE4i32x4,
+                     TargetISA::AVX1i32x8, TargetISA::AVX2i32x8])
+        .out_dir("src/ispc/")
+        .compile("kernel");
+
+    ispc_compile::Config::new()
+        .file("vendor/ISPC Texture Compressor/ispc_texcomp/kernel_astc.ispc")
+        .opt_level(2)
+        .optimization_opt(ispc_compile::OptimizationOpt::FastMath)
+        .woff()
+        .target_isas(vec![TargetISA::SSE2i32x4, TargetISA::SSE4i32x4,
+                     TargetISA::AVX1i32x8, TargetISA::AVX2i32x8])
+        .out_dir("src/ispc/")
+        .compile("kernel_astc");
 }
 
-fn compile_kernel_astc() {
-    let mut cfg = ispc::Config::new();
-    cfg.file("vendor/ISPC Texture Compressor/ispc_texcomp/kernel_astc.ispc");
-    cfg.opt_level(2);
-    cfg.optimization_opt(ispc::opt::OptimizationOpt::FastMath);
-    //cfg.quiet();
-    cfg.woff();
-    //cfg.instrument();
-    cfg.compile("kernel_astc");
+#[cfg(not(feature = "ispc"))]
+fn compile_kernel() {
+    ispc_rt::PackagedModule::new("kernel")
+        .lib_path("src/ispc/")
+        .link();
+
+    ispc_rt::PackagedModule::new("kernel_astc")
+        .lib_path("src/ispc/")
+        .link();
 }
 
 fn main() {
     compile_kernel();
-    compile_kernel_astc();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #[macro_use]
-extern crate ispc;
+extern crate ispc_rt;
 
 pub mod bindings {
     ispc_module!(kernel);


### PR DESCRIPTION
This PR uses the newly split ispc-rs crates, ispc\_compile and ispc\_rs to feature gate the compilation of the ISPC code to fix #2 . The compiled library are portable across vector ISAs by compiling them for multiple ISAs, then ISPC internally will pick the right backend to dispatch the function calls too, based on the host ISA. There's an existing issue in the ISPC compiler which seems to give an ICE if I compile for the KNL and SKX targets as well with optimization enabled, so I just have SSE through AVX2 on the list. I'll open an issue on the ISPC repo shortly with a smaller repro case (this may be a windows specific thing, or fixed in 1.10.0, I'm still looking into this some).

To compile the ISPC libraries and bindings compile with the optional feature enabled, `cargo build --features ispc`. To build with the existing bindings, just compile with `cargo build`. This will select the right pre-compiled library for the corresponding host triple, so to distribute this library you'll need to build the bindings on each OS and package the libraries into the repo. The generated Rust bindings can be taken from any host OS though.